### PR TITLE
Add java runtime detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ python3 -m dependency_resolver -h
 - **apk** - System packages of Alpine
 - **pip** - Python packages
 - **npm** - Node.js packages
-- **maven** - Java packages
+- **maven** - Java packages (build-time dependencies via pom.xml)
+- **java-runtime** - Java packages (runtime JAR files in production environments)
 
 Also captures **Docker container metadata** when analyzing containers.
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -66,7 +66,8 @@ The tool outputs structured JSON with detected package managers and their depend
 {
   "_container-info": { "name": "nginx-container", "image": "nginx:latest", "hash": "sha256:..." },
   "dpkg": { "scope": "system", "dependencies": { "curl": { "version": "7.81.0-1ubuntu1.18 amd64" } } },
-  "pip": { "scope": "project", "location": "/app/venv/lib/python3.12/site-packages", "dependencies": { "numpy": { "version": "1.3.3" } } }
+  "pip": { "scope": "project", "location": "/app/venv/lib/python3.12/site-packages", "dependencies": { "numpy": { "version": "1.3.3" } } },
+  "java-runtime": { "type": "runtime", "location": "/app", "artifacts": { "app.jar": { "version": "1.0.0", "size": 12345, "type": "jar" } } }
 }
 ```
 
@@ -74,8 +75,18 @@ For complete JSON schema documentation, field definitions, and examples, see [do
 
 ### Key Schema Concepts
 
+**Two Detection Models**:
+
+- **Dependency Model**: Uses `scope` field with `dependencies` object (package managers)
+- **Runtime Artifact Model**: Uses `type: "runtime"` field with `artifacts` object (deployment files)
+
+**Fields**:
+
 - **Scope**: `"system"` (system-wide packages) or `"project"` (project-specific packages)
-- **Location**: Path to project-local installations (project scope only)
+- **Type**: `"runtime"` for deployment artifacts
+- **Location**: Path to project-local installations or runtime artifacts
+- **Dependencies**: Installed packages (dependency model)
+- **Artifacts**: Runtime deployment files (runtime model)
 - **Hash**: Dependency integrity verification when available
 - **Container Info**: Docker metadata included as `_container-info`
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -18,7 +18,7 @@ Others:
   - Override default commands (e.g., change from `pip list --format=freeze`)
   - Make it configurable, if the JSON output is pretty-printed or not (at the start pretty-print is default)
   - Add different log levels
-- Extend the set of supported package managers with the common ones for Go, PHP and Java
+- Extend the set of supported package managers with the common ones for Go, PHP, etc.
 - Support more operating systems: RedHat Linux (yum/dnf), openSUSE (zypper)
 - Add extraction of some relevant environment variables
 - Implement auto-completion of container id / name

--- a/dependency_resolver/core/orchestrator.py
+++ b/dependency_resolver/core/orchestrator.py
@@ -6,6 +6,7 @@ from ..detectors.dpkg_detector import DpkgDetector
 from ..detectors.apk_detector import ApkDetector
 from ..detectors.docker_info_detector import DockerInfoDetector
 from ..detectors.maven_detector import MavenDetector
+from ..detectors.java_runtime_detector import JavaRuntimeDetector
 
 
 class Orchestrator:
@@ -25,6 +26,7 @@ class Orchestrator:
             DockerInfoDetector(),
             DpkgDetector(),
             ApkDetector(),
+            JavaRuntimeDetector(debug=debug),
             MavenDetector(debug=debug),
             PipDetector(venv_path=venv_path, debug=debug),
             NpmDetector(debug=debug),
@@ -73,12 +75,19 @@ class Orchestrator:
                             print(f"Found container info for {detector_name}")
                     else:
                         # Standard handling for other detectors
-                        if dependencies.get("dependencies") or self.debug:
+                        # Handle both dependency format and runtime artifact format
+                        has_content = dependencies.get("dependencies") or dependencies.get("artifacts") or self.debug
+                        if has_content:
                             result[detector_name] = dependencies
 
                         if self.debug:
+                            # Count both dependencies and artifacts for debug output
                             dep_count = len(dependencies.get("dependencies", {}))
-                            print(f"Found {dep_count} dependencies for {detector_name}")
+                            artifact_count = len(dependencies.get("artifacts", {}))
+                            if artifact_count > 0:
+                                print(f"Found {artifact_count} artifacts for {detector_name}")
+                            else:
+                                print(f"Found {dep_count} dependencies for {detector_name}")
                 else:
                     if self.debug:
                         print(f"{detector_name} is not available")

--- a/dependency_resolver/detectors/java_runtime_detector.py
+++ b/dependency_resolver/detectors/java_runtime_detector.py
@@ -1,0 +1,253 @@
+import hashlib
+import os
+import re
+from typing import Optional, Any
+
+from ..core.interfaces import EnvironmentExecutor, PackageManagerDetector
+
+
+class JavaRuntimeDetector(PackageManagerDetector):
+    """Detector for Java runtime environments with JAR files."""
+
+    NAME = "java-runtime"
+
+    def __init__(self, debug: bool = False):
+        self.debug = debug
+        self._java_available_cache: bool | None = None
+        self._java_version_cache: dict[str, str] | None = None
+
+    def is_usable(self, executor: EnvironmentExecutor, working_dir: Optional[str] = None) -> bool:
+        """Check if Java runtime is available or JAR files are present."""
+        search_dir = working_dir or "."
+
+        # Check for JAR files in working directory
+        stdout, _, exit_code = executor.execute_command(
+            f"find '{search_dir}' -name '*.jar' -type f | head -1", working_dir
+        )
+        if exit_code == 0 and stdout.strip():
+            return True
+
+        # Check for Java runtime availability
+        return self._java_available(executor, working_dir)
+
+    def get_dependencies(self, executor: EnvironmentExecutor, working_dir: Optional[str] = None) -> dict[str, Any]:
+        """Extract JAR files and Java runtime information."""
+        search_dir = working_dir or "."
+        location = self._resolve_absolute_path(executor, search_dir)
+        artifacts: dict[str, dict[str, Any]] = {}
+
+        result: dict[str, Any] = {"type": "runtime", "location": location}
+
+        # Discover JAR files
+        jar_files = self._discover_jar_files(executor, search_dir)
+
+        # Extract metadata from each JAR
+        for jar_path in jar_files:
+            jar_info = self._extract_jar_metadata(executor, jar_path, search_dir)
+            if jar_info:
+                # Use relative path as artifact name
+                relative_path = jar_path
+                if jar_path.startswith(f"{search_dir}/"):
+                    relative_path = jar_path[len(f"{search_dir}/") :]
+
+                # Convert size to integer and add artifact type
+                artifact_info = {
+                    "version": jar_info.get("version", "unknown"),
+                    "size": int(jar_info.get("size", "0")) if jar_info.get("size", "0").isdigit() else 0,
+                    "type": "jar",
+                    "path": jar_path,
+                }
+                artifacts[relative_path] = artifact_info
+
+        # Add Java runtime environment info if available
+        java_metadata = self._get_java_metadata(executor, working_dir)
+        if java_metadata:
+            runtime_env = {"platform": "java"}
+            if "java_version" in java_metadata:
+                runtime_env["version"] = java_metadata["java_version"]
+            if "java_vendor" in java_metadata:
+                runtime_env["vendor"] = java_metadata["java_vendor"]
+            if "java_runtime" in java_metadata:
+                runtime_env["runtime"] = java_metadata["java_runtime"]
+
+            result["runtime_environment"] = runtime_env
+
+        # Generate location-based hash if we have artifacts
+        if artifacts:
+            result["hash"] = self._generate_location_hash(executor, location)
+
+        result["artifacts"] = artifacts
+        return result
+
+    def has_system_scope(self, executor: EnvironmentExecutor, working_dir: Optional[str] = None) -> bool:
+        """Java runtime detector is always project scope."""
+        return False
+
+    def _java_available(self, executor: EnvironmentExecutor, working_dir: Optional[str] = None) -> bool:
+        """Check if Java runtime is available."""
+        if self._java_available_cache is not None:
+            return self._java_available_cache
+
+        _, _, exit_code = executor.execute_command("java -version", working_dir)
+        self._java_available_cache = exit_code == 0
+        return self._java_available_cache
+
+    def _discover_jar_files(self, executor: EnvironmentExecutor, search_dir: str) -> list[str]:
+        """Find all JAR files in the working directory and subdirectories."""
+        stdout, stderr, exit_code = executor.execute_command(
+            f"find '{search_dir}' -name '*.jar' -type f",
+        )
+
+        if exit_code != 0:
+            if self.debug:
+                print(f"ERROR: JAR file discovery failed: {stderr}")
+            return []
+
+        jar_files = []
+        for line in stdout.strip().split("\n"):
+            jar_path = line.strip()
+            if jar_path:
+                jar_files.append(jar_path)
+
+        return jar_files
+
+    def _extract_jar_metadata(
+        self, executor: EnvironmentExecutor, jar_path: str, working_dir: str  # pylint: disable=unused-argument
+    ) -> dict[str, str] | None:
+        """Extract metadata from a JAR file."""
+        metadata: dict[str, str] = {}
+
+        # Get file size
+        stdout, _, exit_code = executor.execute_command(f"stat -f%z '{jar_path}' 2>/dev/null || stat -c%s '{jar_path}'")
+        if exit_code == 0 and stdout.strip():
+            metadata["size"] = stdout.strip()
+
+        # Try to extract version from manifest
+        version = self._extract_version_from_manifest(executor, jar_path)
+        if version:
+            metadata["version"] = version
+        else:
+            # Try to extract version from filename
+            version = self._extract_version_from_filename(jar_path)
+            if version:
+                metadata["version"] = version
+            else:
+                metadata["version"] = "unknown"
+
+        return metadata if metadata else None
+
+    def _extract_version_from_manifest(self, executor: EnvironmentExecutor, jar_path: str) -> str | None:
+        """Extract version information from JAR manifest."""
+        # Try to read manifest from JAR
+        stdout, _, exit_code = executor.execute_command(f"unzip -q -c '{jar_path}' META-INF/MANIFEST.MF 2>/dev/null")
+
+        if exit_code != 0 or not stdout.strip():
+            return None
+
+        # Parse manifest for version information
+        for line in stdout.split("\n"):
+            line = line.strip()
+            # Look for common version attributes
+            for version_key in ["Implementation-Version", "Bundle-Version", "Version", "Specification-Version"]:
+                if line.startswith(f"{version_key}:"):
+                    version = line.split(":", 1)[1].strip()
+                    if version and version != "null":
+                        return version
+
+        return None
+
+    def _extract_version_from_filename(self, jar_path: str) -> str | None:
+        """Extract version from JAR filename using common patterns."""
+        filename = os.path.basename(jar_path)
+
+        # Remove .jar extension first
+        if filename.endswith(".jar"):
+            base_name = filename[:-4]
+        else:
+            base_name = filename
+
+        # Common patterns: name-version.jar, name_version.jar
+        # Use more flexible patterns that work with complex names like commons-lang3
+        patterns = [
+            r"^(.+)[-_](\d+(?:\.\d+)*(?:-[A-Za-z0-9]+)?)$",  # name-1.2.3 or name-1.2.3-SNAPSHOT
+            r"^(.+)[-_]v(\d+(?:\.\d+)*)$",  # name-v1.2.3
+            r"^(.+?)(\d+(?:\.\d+)*(?:-[A-Za-z0-9]+)?)$",  # name1.2.3 (no separator)
+        ]
+
+        for pattern in patterns:
+            match = re.match(pattern, base_name)
+            if match:
+                return match.group(2)
+
+        return None
+
+    def _get_java_metadata(
+        self, executor: EnvironmentExecutor, working_dir: Optional[str] = None
+    ) -> dict[str, str] | None:
+        """Get Java runtime metadata."""
+        if not self._java_available(executor, working_dir):
+            return None
+
+        if self._java_version_cache is not None:
+            return self._java_version_cache
+
+        stdout, stderr, exit_code = executor.execute_command("java -version", working_dir)
+        if exit_code != 0:
+            return None
+
+        metadata: dict[str, str] = {}
+
+        # Parse java -version output (goes to stderr typically)
+        version_output = stderr if stderr else stdout
+
+        # Extract Java version
+        version_match = re.search(r'version "([^"]+)"', version_output)
+        if version_match:
+            metadata["java_version"] = version_match.group(1)
+
+        # Extract vendor/runtime info
+        lines = version_output.split("\n")
+        for line in lines:
+            line = line.strip()
+            if "Runtime Environment" in line:
+                # Extract runtime name
+                runtime_match = re.search(r"([^(]+Runtime Environment)", line)
+                if runtime_match:
+                    metadata["java_runtime"] = runtime_match.group(1).strip()
+            elif "VM" in line and "(" in line:
+                # Extract vendor from VM line
+                vendor_match = re.search(r"\(([^)]+)\)", line)
+                if vendor_match:
+                    metadata["java_vendor"] = vendor_match.group(1).strip()
+
+        self._java_version_cache = metadata if metadata else None
+        return self._java_version_cache
+
+    def _resolve_absolute_path(self, executor: EnvironmentExecutor, path: str) -> str:
+        """Resolve absolute path within the executor's context."""
+        if path == ".":
+            stdout, stderr, exit_code = executor.execute_command("pwd")
+            if exit_code == 0 and stdout.strip():
+                return stdout.strip()
+            raise RuntimeError(f"Failed to resolve current directory in executor context: {stderr}")
+        else:
+            stdout, stderr, exit_code = executor.execute_command(f"cd '{path}' && pwd")
+            if exit_code == 0 and stdout.strip():
+                return stdout.strip()
+            raise RuntimeError(f"Failed to resolve path '{path}' in executor context: {stderr}")
+
+    def _generate_location_hash(self, executor: EnvironmentExecutor, location: str) -> str:
+        """Generate a hash based on JAR files and their metadata."""
+        stdout, stderr, exit_code = executor.execute_command(
+            f"cd '{location}' && find . -name '*.jar' -type f -printf '%s %p\\n' | LC_COLLATE=C sort -k2,2"
+        )
+
+        if exit_code == 0 and stdout.strip():
+            content = stdout.strip()
+            return hashlib.sha256(content.encode()).hexdigest()
+        else:
+            if self.debug:
+                print(f"ERROR: java_runtime_detector hash generation command failed with exit code {exit_code}")
+                print(f"ERROR: location: {location}")
+                print(f"ERROR: stderr: {stderr}")
+            return ""

--- a/docs/technical/detectors/java_runtime_detector.md
+++ b/docs/technical/detectors/java_runtime_detector.md
@@ -1,0 +1,169 @@
+# Java Runtime Detector
+
+## Overview
+
+The Java Runtime Detector identifies Java applications in production environments by detecting JAR files and Java runtime information. It complements the Maven detector by targeting environments where JAR files exist but Maven build tools are unavailable (e.g., production containers).
+
+## Type and Scope
+
+- **Type**: `runtime` - Detects runtime artifacts rather than installed dependencies
+- **Target Environments**: Production containers, runtime environments with JAR files
+- **Working Directory**: Scans the specified working directory and subdirectories for JAR files
+- **Complementary**: Works alongside Maven detector (Maven handles build-time dependencies, Java Runtime handles runtime artifacts)
+
+## Detection Logic
+
+### Usability Check (`is_usable`)
+
+The detector considers an environment usable if either condition is met:
+
+1. **JAR Files Present**: Any `.jar` files found in working directory or subdirectories
+2. **Java Runtime Available**: `java -version` command executes successfully
+
+### Runtime Artifact Extraction (`get_dependencies`)
+
+1. **JAR Discovery**: Uses `find` to locate all `.jar` files recursively
+2. **Artifact Metadata Extraction**: For each JAR file:
+   - File size via `stat` command (converted to integer)
+   - Version from JAR manifest (META-INF/MANIFEST.MF)
+   - Fallback version extraction from filename patterns
+   - Full path location of the artifact
+3. **Runtime Environment Info**: Collects Java runtime information via `java -version`
+4. **Location Hash**: Generates Tier 2 hash based on JAR file list and sizes
+
+### Version Extraction Strategy
+
+**Priority Order**:
+
+1. **JAR Manifest**: Looks for version attributes in META-INF/MANIFEST.MF:
+   - Implementation-Version
+   - Bundle-Version
+   - Version
+   - Specification-Version
+2. **Filename Patterns**: Extracts version from filename using regex patterns:
+   - `name-1.2.3.jar`
+   - `name_1.2.3.jar`
+   - `name-v1.2.3.jar`
+3. **Fallback**: Sets version as "unknown" if no version found
+
+## Hash Strategy
+
+**Tier 2 - Location-based**: Generates SHA256 hash from:
+
+- List of all JAR files in working directory
+- File sizes for each JAR
+- Sorted consistently using `LC_COLLATE=C sort`
+
+This provides change detection when JARs are added, removed, or modified.
+
+## Limitations
+
+1. **No Transitive Dependencies**: Cannot resolve dependencies between JARs
+2. **Runtime-Only**: Provides JAR inventory, not complete dependency tree
+3. **Limited Version Detection**: Depends on manifest quality and filename conventions
+4. **No Build-Time Info**: Cannot access original build dependencies or configurations
+
+## Example Output
+
+```json
+{
+  "type": "runtime",
+  "location": "/app",
+  "runtime_environment": {
+    "platform": "java",
+    "version": "17.0.8",
+    "vendor": "Eclipse Adoptium",
+    "runtime": "OpenJDK Runtime Environment"
+  },
+  "artifacts": {
+    "my-application.jar": {
+      "version": "1.2.3",
+      "size": 15728640,
+      "type": "jar",
+      "path": "/app/my-application.jar"
+    },
+    "lib/commons-lang3-3.12.0.jar": {
+      "version": "3.12.0",
+      "size": 587264,
+      "type": "jar",
+      "path": "/app/lib/commons-lang3-3.12.0.jar"
+    },
+    "lib/spring-boot-2.7.0.jar": {
+      "version": "2.7.0",
+      "size": 1245184,
+      "type": "jar",
+      "path": "/app/lib/spring-boot-2.7.0.jar"
+    },
+    "legacy-app.jar": {
+      "version": "unknown",
+      "size": 2048000,
+      "type": "jar",
+      "path": "/app/legacy-app.jar"
+    }
+  },
+  "hash": "sha256:abc123def456..."
+}
+```
+
+## Use Cases
+
+### Production Container Scanning
+
+```bash
+# Scan production container with JAR files but no Maven
+python3 -m dependency_resolver docker my-prod-container
+```
+
+### Runtime Environment Analysis
+
+```bash
+# Analyze JAR-based application in working directory
+python3 -m dependency_resolver host --working-dir /opt/myapp
+```
+
+### Complementary with Maven
+
+- **Development**: Maven detector provides complete build dependencies
+- **Production**: Java Runtime detector provides deployed JAR inventory
+- **Combined**: Full lifecycle dependency visibility
+
+## Technical Notes
+
+### JAR Manifest Parsing
+
+- Uses `unzip -q -c` to extract manifest without temporary files
+- Handles various manifest formats and encoding issues
+- Gracefully falls back to filename parsing on manifest read failures
+
+### File Size Calculation
+
+- Uses `stat` command with BSD/GNU compatibility (`-f%z` with `-c%s` fallback)
+- Provides byte-accurate size information for change detection
+
+### Java Version Parsing
+
+- Parses `java -version` stderr/stdout output
+- Extracts version, runtime name, and vendor information
+- Handles various Java distribution output formats
+
+### Performance Considerations
+
+- `find` command limited to working directory scope
+- Caches Java availability and version info to avoid repeated calls
+- Uses efficient `head -1` for initial JAR detection in usability check
+
+## Error Handling
+
+- **Missing Java**: Gracefully continues with JAR-only detection
+- **JAR Read Failures**: Logs debug info, continues with other JARs
+- **Command Failures**: Returns empty artifacts instead of exceptions
+- **Permission Issues**: Handles restricted file access gracefully
+
+## Integration
+
+The detector integrates seamlessly with the orchestrator priority system:
+
+1. Runs after system package detectors (dpkg, apk)
+2. Runs before Maven detector (complements rather than conflicts)
+3. Project scope ensures proper working directory handling
+4. Debug mode provides detailed extraction logging

--- a/tests/detectors/java_runtime/README.md
+++ b/tests/detectors/java_runtime/README.md
@@ -1,0 +1,169 @@
+# Java Runtime Detector Tests
+
+## Docker Test
+
+The Java Runtime detector tests use Docker containers to simulate production environments where JAR files are present with or without Java runtime tools.
+
+## Image Used
+
+- **Primary**: `eclipse-temurin:17-jre` - Modern OpenJDK 17 runtime environment
+- **Secondary**: `alpine:latest` - Minimal Linux for testing JAR detection without Java runtime
+
+## Test Commands
+
+The tests verify the following functionality:
+
+- `java -version` (Java runtime verification)
+- JAR file discovery using `find` command
+- JAR manifest parsing using `unzip` command
+- File size detection using `stat` command
+- Hash generation using `find` and `sort` commands
+
+## Test Scenarios
+
+### 1. Full Java Runtime Detection (`test_java_runtime_docker_container_detection`)
+
+**Environment**: eclipse-temurin:17-jre with created test JAR files
+
+**Setup**:
+
+- Creates `/tmp/test-java-app/` directory structure
+- Generates test JAR files with different version detection scenarios:
+  - `test-app-1.2.3.jar` - JAR with manifest-based version
+  - `lib/commons-lang3-3.12.0.jar` - JAR with filename-based version
+  - `lib/legacy.jar` - JAR without version information
+  - `spring-boot.jar` - Larger JAR file for size testing
+
+**Validates**:
+
+- Correct scope (`project`)
+- JAR file discovery and metadata extraction
+- Version parsing from manifests and filenames
+- Java runtime metadata collection
+- Location-based hash generation
+
+### 2. Java Available, No JARs (`test_java_runtime_no_jars_but_java_available`)
+
+**Environment**: eclipse-temurin:17-jre with empty directory
+
+**Validates**:
+
+- Detector correctly reports no dependencies when no JAR files present
+- Java runtime availability doesn't trigger detection without JARs
+
+### 3. JARs Present, No Java (`test_java_runtime_jars_no_java`)
+
+**Environment**: alpine:latest (no Java) with created JAR files
+
+**Validates**:
+
+- JAR-based detection works without Java runtime
+- Missing Java metadata when Java unavailable
+- Detector prioritizes JAR file presence over Java availability
+
+## Running Tests
+
+### All Java Runtime Tests
+
+```bash
+pytest tests/detectors/java_runtime/
+```
+
+### Verbose Output
+
+```bash
+pytest tests/detectors/java_runtime/ --verbose-resolver
+```
+
+### Specific Test
+
+```bash
+# Full detection test
+pytest tests/detectors/java_runtime/test_java_runtime_docker_detection.py::TestJavaRuntimeDockerDetection::test_java_runtime_docker_container_detection
+
+# No JARs test
+pytest tests/detectors/java_runtime/test_java_runtime_docker_detection.py::TestJavaRuntimeDockerDetection::test_java_runtime_no_jars_but_java_available
+
+# No Java test
+pytest tests/detectors/java_runtime/test_java_runtime_docker_detection.py::TestJavaRuntimeDockerDetection::test_java_runtime_jars_no_java
+```
+
+### Debug Mode
+
+```bash
+pytest tests/detectors/java_runtime/ -s --tb=short
+```
+
+## Expected Test Output
+
+### Successful Detection
+
+```json
+{
+  "java-runtime": {
+    "scope": "project",
+    "location": "/tmp/test-java-app",
+    "dependencies": {
+      "test-app-1.2.3.jar": {
+        "version": "1.2.3",
+        "size": "1234"
+      },
+      "lib/commons-lang3-3.12.0.jar": {
+        "version": "3.12.0",
+        "size": "5678"
+      },
+      "lib/legacy.jar": {
+        "version": "unknown",
+        "size": "9012"
+      }
+    },
+    "metadata": {
+      "java_version": "17.0.8",
+      "java_runtime": "OpenJDK Runtime Environment",
+      "java_vendor": "Eclipse Adoptium"
+    },
+    "hash": "sha256:abc123..."
+  }
+}
+```
+
+## Test Requirements
+
+- Docker must be available and running
+- Python `docker` package installed (`pip install docker`)
+- Sufficient disk space for test container images
+- Network access to pull Docker images
+
+## Troubleshooting
+
+### Docker Permission Issues
+
+```bash
+# Add user to docker group (requires logout/login)
+sudo usermod -aG docker $USER
+```
+
+### Container Startup Failures
+
+```bash
+# Verify Docker daemon is running
+systemctl status docker
+
+# Check available images
+docker images | grep temurin
+```
+
+### Test Timeout Issues
+
+```bash
+# Increase timeout for slow networks
+export DOCKER_TEST_TIMEOUT=120
+pytest tests/detectors/java_runtime/
+```
+
+## Performance Notes
+
+- Tests create minimal JAR files (< 1MB total) for fast execution
+- Container startup typically takes 10-30 seconds
+- Full test suite runs in under 2 minutes on modern hardware
+- Cleanup is performed automatically even on test failures

--- a/tests/detectors/java_runtime/__init__.py
+++ b/tests/detectors/java_runtime/__init__.py
@@ -1,0 +1,1 @@
+# Java Runtime detector tests

--- a/tests/detectors/java_runtime/test_java_runtime_docker_detection.py
+++ b/tests/detectors/java_runtime/test_java_runtime_docker_detection.py
@@ -1,0 +1,262 @@
+"""Test Java runtime Docker container dependency detection."""
+
+import os
+import sys
+from typing import Dict, Any
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+import pytest
+from dependency_resolver.executors import DockerExecutor
+from dependency_resolver.core.orchestrator import Orchestrator
+from tests.common.docker_test_base import DockerTestBase
+
+try:
+    import docker
+except ImportError:
+    docker = None  # type: ignore
+
+
+class TestJavaRuntimeDockerDetection(DockerTestBase):
+    """Test Java runtime dependency detection using Docker container environment."""
+
+    TEST_IMAGE = "eclipse-temurin:17-jre"
+
+    @pytest.mark.skipif(docker is None, reason="Docker not available")
+    def test_java_runtime_docker_container_detection(self, request: pytest.FixtureRequest) -> None:
+        """Test Java runtime dependency detection inside a Docker container."""
+
+        verbose_output = self.setup_verbose_output(request)
+        container_id = None
+
+        try:
+            container_id = self.start_container(self.TEST_IMAGE, additional_args=[])
+            self.wait_for_container_ready(container_id, "java -version", max_wait=60)
+
+            # Create sample JAR files for testing
+            self._setup_test_jar_files(container_id)
+
+            executor = DockerExecutor(container_id)
+            orchestrator = Orchestrator(debug=False, skip_system_scope=False)
+
+            result = orchestrator.resolve_dependencies(executor, working_dir="/tmp/test-java-app")
+
+            if verbose_output:
+                self.print_verbose_results("DEPENDENCY RESOLVER OUTPUT:", result)
+
+            self._validate_java_runtime_dependencies(result)
+
+        finally:
+            if container_id:
+                self.cleanup_container(container_id)
+
+    def _setup_test_jar_files(self, container_id: str) -> None:
+        """Create test JAR files with manifests for detection testing."""
+        # Create test directory
+        docker_client = docker.from_env()
+        container = docker_client.containers.get(container_id)
+
+        # Install zip utility first - update package list only if needed
+        result = container.exec_run(["apt-get", "update"])
+        result = container.exec_run(["apt-get", "install", "-y", "zip"])
+        if result.exit_code != 0:
+            print(f"Failed to install zip: {result.output.decode()}")
+
+        # Create application directory
+        result = container.exec_run(["mkdir", "-p", "/tmp/test-java-app/lib"])
+        if result.exit_code != 0:
+            print(f"Failed to create directories: {result.output.decode()}")
+
+        # Create working directory for temp files
+        result = container.exec_run(["mkdir", "-p", "/tmp/work"])
+
+        # Create a simple dummy file for JARs
+        result = container.exec_run(["sh", "-c", "echo 'dummy content' > /tmp/work/dummy.txt"])
+
+        # Create manifest file with proper format
+        manifest_content = "Manifest-Version: 1.0\\nImplementation-Title: test-app\\nImplementation-Version: 1.2.3\\nImplementation-Vendor: Test Company\\nMain-Class: com.example.TestApp\\n\\n"
+
+        # Create META-INF directory and manifest
+        result = container.exec_run(["mkdir", "-p", "/tmp/work/META-INF"])
+        result = container.exec_run(["sh", "-c", f"echo -e '{manifest_content}' > /tmp/work/META-INF/MANIFEST.MF"])
+
+        # Create JAR with manifest using working directory approach
+        result = container.exec_run(
+            ["sh", "-c", "cd /tmp/work && zip -r /tmp/test-java-app/test-app-1.2.3.jar META-INF/"]
+        )
+        if result.exit_code != 0:
+            print(f"Failed to create test-app JAR: {result.output.decode()}")
+
+        # Create another JAR with filename-based version
+        result = container.exec_run(
+            ["sh", "-c", "cd /tmp/work && zip /tmp/test-java-app/lib/commons-lang3-3.12.0.jar dummy.txt"]
+        )
+        if result.exit_code != 0:
+            print(f"Failed to create commons JAR: {result.output.decode()}")
+
+        # Create JAR without version info
+        result = container.exec_run(["sh", "-c", "cd /tmp/work && zip /tmp/test-java-app/lib/legacy.jar dummy.txt"])
+        if result.exit_code != 0:
+            print(f"Failed to create legacy JAR: {result.output.decode()}")
+
+        # Create a larger JAR to test different sizes
+        result = container.exec_run(
+            ["sh", "-c", "dd if=/dev/zero of=/tmp/work/large.txt bs=1024 count=100 2>/dev/null"]
+        )
+        result = container.exec_run(["sh", "-c", "cd /tmp/work && zip /tmp/test-java-app/spring-boot.jar large.txt"])
+        if result.exit_code != 0:
+            print(f"Failed to create spring-boot JAR: {result.output.decode()}")
+
+        # Verify files were created
+        result = container.exec_run(["ls", "-la", "/tmp/test-java-app/", "/tmp/test-java-app/lib/"])
+        print(f"Created files: {result.output.decode()}")
+
+    def _validate_java_runtime_dependencies(self, result: Dict[str, Any]) -> None:
+        """Validate Java runtime artifacts in the result."""
+        assert "java-runtime" in result
+
+        java_runtime_result = result["java-runtime"]
+        assert "type" in java_runtime_result
+        assert java_runtime_result["type"] == "runtime"
+        assert "location" in java_runtime_result
+        assert "artifacts" in java_runtime_result
+
+        artifacts = java_runtime_result["artifacts"]
+        assert isinstance(artifacts, dict)
+        assert len(artifacts) > 0
+
+        # Validate that we detected our test JAR files
+        jar_names = list(artifacts.keys())
+
+        # Should find our test JARs
+        assert any("test-app" in jar for jar in jar_names), f"test-app JAR not found in {jar_names}"
+        assert any("commons-lang3" in jar for jar in jar_names), f"commons-lang3 JAR not found in {jar_names}"
+        assert any("legacy.jar" in jar for jar in jar_names), f"legacy.jar not found in {jar_names}"
+        assert any("spring-boot.jar" in jar for jar in jar_names), f"spring-boot.jar not found in {jar_names}"
+
+        # Validate JAR artifact structure
+        for jar_info in artifacts.values():
+            assert "version" in jar_info
+            assert "size" in jar_info
+            assert "type" in jar_info
+            assert "path" in jar_info
+            assert isinstance(jar_info["version"], str)
+            assert isinstance(jar_info["size"], int)
+            assert jar_info["type"] == "jar"
+            assert jar_info["size"] > 0  # Size should be positive
+            assert jar_info["path"].startswith("/")  # Absolute path
+
+        # Validate specific version extraction
+        test_app_jar = next((name for name in jar_names if "test-app" in name), None)
+        if test_app_jar:
+            assert artifacts[test_app_jar]["version"] == "1.2.3"
+
+        commons_jar = next((name for name in jar_names if "commons-lang3" in name), None)
+        if commons_jar:
+            assert artifacts[commons_jar]["version"] == "3.12.0"
+
+        legacy_jar = next((name for name in jar_names if "legacy.jar" in name), None)
+        if legacy_jar:
+            assert artifacts[legacy_jar]["version"] == "unknown"
+
+        # Validate Java runtime environment if present
+        if "runtime_environment" in java_runtime_result:
+            runtime_env = java_runtime_result["runtime_environment"]
+            assert "platform" in runtime_env
+            assert runtime_env["platform"] == "java"
+            if "version" in runtime_env:
+                assert runtime_env["version"].startswith("17")
+            if "runtime" in runtime_env:
+                assert "Runtime Environment" in runtime_env["runtime"]
+            if "vendor" in runtime_env:
+                assert len(runtime_env["vendor"]) > 0
+
+        # Validate hash is present
+        assert "hash" in java_runtime_result
+        assert len(java_runtime_result["hash"]) == 64  # SHA256 hex string
+
+    @pytest.mark.skipif(docker is None, reason="Docker not available")
+    def test_java_runtime_no_jars_but_java_available(self, request: pytest.FixtureRequest) -> None:
+        """Test Java runtime detection when Java is available but no JARs present."""
+
+        verbose_output = self.setup_verbose_output(request)
+        container_id = None
+
+        try:
+            container_id = self.start_container(self.TEST_IMAGE, additional_args=[])
+            self.wait_for_container_ready(container_id, "java -version", max_wait=60)
+
+            executor = DockerExecutor(container_id)
+            orchestrator = Orchestrator(debug=False, skip_system_scope=False)
+
+            # Test in empty directory
+            result = orchestrator.resolve_dependencies(executor, working_dir="/tmp")
+
+            if verbose_output:
+                self.print_verbose_results("DEPENDENCY RESOLVER OUTPUT (No JARs):", result)
+
+            # Should not detect java-runtime without JAR files
+            assert "java-runtime" not in result or len(result.get("java-runtime", {}).get("artifacts", {})) == 0
+
+        finally:
+            if container_id:
+                self.cleanup_container(container_id)
+
+    @pytest.mark.skipif(docker is None, reason="Docker not available")
+    def test_java_runtime_jars_no_java(self, request: pytest.FixtureRequest) -> None:
+        """Test Java runtime detection when JARs exist but Java is not available."""
+
+        verbose_output = self.setup_verbose_output(request)
+        container_id = None
+
+        try:
+            # Use a minimal image without Java runtime
+            container_id = self.start_container("alpine:latest", additional_args=[])
+            self.wait_for_container_ready(container_id, "echo ready", max_wait=30)
+
+            # Create sample JAR files without Java runtime
+            docker_client = docker.from_env()
+            container = docker_client.containers.get(container_id)
+
+            # Install zip and create directories
+            result = container.exec_run(["apk", "add", "--no-cache", "zip"])
+            if result.exit_code != 0:
+                print(f"Failed to install zip: {result.output.decode()}")
+
+            result = container.exec_run(["mkdir", "-p", "/tmp/test-java-app"])
+            result = container.exec_run(["mkdir", "-p", "/tmp/work"])
+
+            # Create dummy content file
+            result = container.exec_run(["sh", "-c", "echo 'fake jar content' > /tmp/work/dummy.txt"])
+
+            # Create JAR file using proper shell command
+            result = container.exec_run(["sh", "-c", "cd /tmp/work && zip /tmp/test-java-app/app.jar dummy.txt"])
+            if result.exit_code != 0:
+                print(f"Failed to create app.jar: {result.output.decode()}")
+
+            # Verify file was created
+            result = container.exec_run(["ls", "-la", "/tmp/test-java-app/"])
+            print(f"Created files in Alpine: {result.output.decode()}")
+
+            executor = DockerExecutor(container_id)
+            orchestrator = Orchestrator(debug=False, skip_system_scope=False)
+
+            dependencies_result = orchestrator.resolve_dependencies(executor, working_dir="/tmp/test-java-app")
+
+            if verbose_output:
+                self.print_verbose_results("DEPENDENCY RESOLVER OUTPUT (JARs, No Java):", dependencies_result)
+
+            # Should detect java-runtime based on JAR files even without Java runtime
+            assert "java-runtime" in dependencies_result
+            java_runtime_result = dependencies_result["java-runtime"]
+            assert java_runtime_result["type"] == "runtime"
+            assert len(java_runtime_result["artifacts"]) > 0
+            assert "app.jar" in java_runtime_result["artifacts"]
+
+            # Should not have Java runtime environment since Java is not available
+            assert "runtime_environment" not in java_runtime_result
+
+        finally:
+            if container_id:
+                self.cleanup_container(container_id)


### PR DESCRIPTION
Introduces a new detection type "runtime". This makes sense to be able to get information e.g. about the java runtime environment and its artifacts (JAR files). Until now we only had detectors that collected "dependencies".

Marked as draft. Have to be discussed with Arne and Didi.


If it should be added, some more refactorings are required, e.g. changing the parent class of `JavaRuntimeDetector` from `PackageManagerDetector` to a new base class `RuntimeDetector`.